### PR TITLE
Add Archivers slack team

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ This list of tools and software is intended to briefly describe some of the most
 
 * Ask [@netpreserve](https://twitter.com/NetPreserve) for access to the [IIPC Slack](https://iipc.slack.com/)
 * [Fill out this request form](https://docs.google.com/forms/d/e/1FAIpQLScXPIH0Ssw63yWqyMkUqHVYmz2-ItBMzHiJQ-sOlJwTA8u5AQ/viewform?usp=sf_link) for access to the [Archives Unleashed Slack](https://archivesunleashed.slack.com/), a researcher group of people working with web archives.
+* [Invite yourself](https://archivers-slack.herokuapp.com/) to the [Archivers Slack](https://archivers.slack.com), a multi-disciplinary effort for archiving projects run in affiliation with [EDGI](https://envirodatagov.org/archiving/) and [Data Together](http://datatogether.org/).
 
 #### Twitter
 


### PR DESCRIPTION
The Archivers Slack is the place where these communities live:
- [EDGI's Website Change Monitoring project](https://github.com/edgi-govdata-archiving/web-monitoring), and
- a dataset archiving spin-off project called [Data Together](datatogether.org), an evolving conversation between [Protocol Lab's IPFS](ipfs.io) [qri.io](qri.io), [EDGI](envirodatagov.org), and other partners. An [intro presentation was given](http://freegovinfo.info/node/12119) at Code{4}Lib conference.

cc: @b5 @mhucka @dcwalk