### PR TITLE
Move ArchiveFacebook to Deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,6 @@ This list of tools and software is intended to briefly describe some of the most
 
 #### Acquisition
 
-* [ArchiveFacebook](https://addons.mozilla.org/en-US/firefox/addon/archivefacebook/) (Stable)	- A [Mozilla Firefox](https://www.mozilla.org/en-US/firefox/new/) add-on for individuals to archive their Facebook accounts.
-
 * [archivenow](https://github.com/oduwsdl/archivenow) (Stable)	- A [Python library](http://ws-dl.blogspot.com/2017/02/2017-02-22-archive-now-archivenow.html) to push web resources into on-demand web archives.
 
 * [Brozzler](https://github.com/internetarchive/brozzler) (Stable) - A distributed web crawler (爬虫) that uses a real browser (chrome or chromium) to fetch pages and embedded urls and to extract links.
@@ -188,6 +186,8 @@ This list of tools and software is intended to briefly describe some of the most
 ----
 
 ### Deprecated
+
+* [ArchiveFacebook](https://addons.mozilla.org/en-US/firefox/addon/archivefacebook/) (Abandoned)	- A [Mozilla Firefox](https://www.mozilla.org/en-US/firefox/new/) add-on for individuals to archive their Facebook accounts.
 
 * [pywb Wayback Web Recorder (Archiver)](https://github.com/ikreymer/pywb-webrecorder) (Sunsetted) - A bare-bones example of how to create a simple web recording and replay system.
 


### PR DESCRIPTION
Project's FF addons page is disabled. Source appears to have been ported from Google Code in anticipation of updates that didn't materialize: https://groups.google.com/forum/?hl=en#!topic/archivefacebook/_m8KeOTnBng