### PR TITLE
Add link to Chronicler

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ This list of tools and software is intended to briefly describe some of the most
 
 * [Brozzler](https://github.com/internetarchive/brozzler) (Stable) - A distributed web crawler (爬虫) that uses a real browser (chrome or chromium) to fetch pages and embedded urls and to extract links.
 
+* [Chronicler](https://github.com/CGamesPlay/chronicler) (In Development) - Web browser with record and replay functionality.
+
 * [Crawl](https://git.autistici.org/ale/crawl) (Stable) - A simple web crawler in Golang.
 
 * [crocoite](https://github.com/promyloph/crocoite) (In Development) - Crawl websites using headless Google Chrome/Chromium and save resources, static DOM snapshot and page screenshots to WARC files.


### PR DESCRIPTION
I used this list when I was looking for a solution for archiving documentation but nothing fit exactly what I was looking to do. I ended up building a tool myself, which is a combination of Webrecorder and Webrecorder Player, with some extra features. I'd like to spread the word about it, so I'm suggesting adding it to this list.