### PR TITLE
Add py-wasapi-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ This list of tools and software is intended to briefly describe some of the most
 
 * [OutbackCDX](https://github.com/nla/outbackcdx) (Stable) - RocksDB-based capture index (CDX) server supporting incremental updates and compression. Can be used as backend for OpenWayback, PyWb and [Heritrix](https://github.com/ukwa/ukwa-heritrix/blob/master/src/main/java/uk/bl/wap/modules/uriuniqfilters/OutbackCDXRecentlySeenUriUniqFilter.java).
 
+* [py-wasapi-client](https://github.com/unt-libraries/py-wasapi-client) (Stable) - Command line application to download crawls from WASAPI. (Python)
+
 * [The Archive Browser](https://archivebrowser.c3.cx/) - The Archive Browser is a program that lets you browse the contents of archives, as well as extract them. It will let you open files from inside archives, and lets you preview them using Quick Look. WARC is supported. (OSX only, Proprietary app)
 
 * [The Unarchiver](http://unarchiver.c3.cx/unarchiver) - Program to extract the contents of many archive formats, inclusive of WARC, to a file system. Free variant of The Archive Browser. (OSX only, Proprietary app)


### PR DESCRIPTION
Adds a link to py-wasapi-client in the Utilities section.