### PR TITLE
Add Mink

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ This list of tools and software is intended to briefly describe some of the most
 
 ### Search & Discovery
 
+* [Mink](https://github.com/machawk1/mink) - A [Google Chrome](https://www.google.com/intl/en/chrome/browser/) extension for querying Memento aggregators while browsing and integrating live-archived web navigation. (Stable)
 * [SecurityTrails](https://securitytrails.com/) - Web based archive for WHOIS and DNS records. REST API available free of charge. 
 * [Tempas v1](http://tempas.L3S.de/v1) - Temporal web archive search based on [Delicious](https://en.wikipedia.org/wiki/Delicious_(website)) tags. (Stable)
 * [Tempas v2](http://tempas.L3S.de/v2) - Temporal web archive search based on links and anchor texts extracted from the German web from 1996 to 2013 (results are not limited to German pages, e.g., [Obama@2005-2009 in Tempas](http://tempas.l3s.de/v2/query?q=obama&from=2005&to=2009)). (Stable)


### PR DESCRIPTION
Discussed this with @ibnesayeed with regard to relevance for inclusion and placement. Mink is originally based off of @anjackson's [Tachyon](https://github.com/ukwa/tachyon/) (the first incarnation) and evolved into its own tool for discovery and pushing URIs to archives' submission interfaces.

Also publicly available in the [Chrome Webstore](https://chrome.google.com/webstore/detail/mink-integrate-live-archi/jemoalkmipibchioofomhkgimhofbbem).