### PR TITLE
Fix Twitter links

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,5 +181,5 @@ This list of tools and software is intended to briefly describe some of the most
 
 ### Twitter
 
-* [@NetPreserve](https://twitter.com/NetPreserve) - Official IIPC Handle.
+* [@NetPreserve](https://twitter.com/NetPreserve) - Official IIPC handle.
 * [#WebArchiving](https://twitter.com/search?q=%23webarchiving)

--- a/README.md
+++ b/README.md
@@ -181,5 +181,5 @@ This list of tools and software is intended to briefly describe some of the most
 
 ### Twitter
 
-* [IIPC](https://twitter.com/NetPreserve)
-* [#webarchives](https://twitter.com/search?f=tweets&vertical=default&q=%23webarchives&src=typd)
+* [@NetPreserve](https://twitter.com/NetPreserve) - Official IIPC Handle.
+* [#WebArchiving](https://twitter.com/search?q=%23webarchiving)


### PR DESCRIPTION
* Added description to the official handle of IIPC.
* Changed `#webarchives` hashtag to `#WebArchiving` as the latter has lately been used more commonly.

Should we also add `#WebArchiveWednesday`?