### PR TITLE
Correct the link for "Web as History"

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ This list of tools and software is intended to briefly describe some of the most
 
 * [IIPC Blog](https://netpreserveblog.wordpress.com/)
 * [Web Archiving Roundtable](https://webarchivingrt.wordpress.com/) - Unofficial blog of the Web Archiving Roundtable of the [Society of American Archivists](https://www2.archivists.org/) maintained by the members of the Web Archiving Roundtable.
-* [The Web as History](http://www.ucl.ac.uk/ucl-press/browse-books/the-web-as-history) - An open-source book that provides a conceptual overview to web archiving research, as well as several case studies.
+* [The Web as History](https://www.uclpress.co.uk/products/84010) - An open-source book that provides a conceptual overview to web archiving research, as well as several case studies.
 * [WS-DL Blog](https://ws-dl.blogspot.com/) - Web Science and Digital Libraries Research Group blogs about various Web archining related topics, scholarly work, and academic trip reports.
 * [DSHR's Blog](https://blog.dshr.org/) - David Rosenthal regularly reviews and summarizes work done in the Digital Preservation field.
 * [UK Web Archive Blog](https://blogs.bl.uk/webarchive/)


### PR DESCRIPTION
The Web as History link seems to be redirecting now to more generic web books at UCL. Although not uninteresting, for example: ["Visualizing Facebook"](https://www.uclpress.co.uk/products/83999) is the page that comes up for me.

Web as History seems to be: https://www.uclpress.co.uk/products/84010.

This is reflected in this commit. 

