### PR TITLE
Add Wayback-Archive to Acquisition section

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ This list of tools and software is intended to briefly describe some of the most
 * [Warcworker](https://github.com/peterk/warcworker) - An open source, dockerized, queued, high fidelity web archiver based on Squidwarc with a simple web GUI. *(Stable)*
 * [Wayback](https://github.com/wabarc/wayback) - A toolkit for snapshot webpage to Internet Archive, archive.today, IPFS and beyond. *(Stable)*
 * [Waybackpy](https://github.com/akamhy/waybackpy) -  Wayback Machine Save, CDX and availability API interface in Python and a command-line tool  *(Stable)*
+* [Wayback-Archive](https://github.com/GeiserX/Wayback-Archive) - Download complete websites from the Wayback Machine with full asset preservation, Google Fonts support, and automatic artifact cleanup for offline viewing. *(Stable)*
 * [Web2Warc](https://github.com/helgeho/Web2Warc) - An easy-to-use and highly customizable crawler that enables anyone to create their own little Web archives (WARC/CDX). *(Stable)*
 * [Web Curator Tool](https://webcuratortool.org) - Open-source workflow management for selective web archiving. *(Stable)*
 * [WebMemex](https://github.com/WebMemex) - Browser extension for Firefox and Chrome which lets you archive web pages you visit. *(In Development)*


### PR DESCRIPTION
## Summary

- Adds [Wayback-Archive](https://github.com/GeiserX/Wayback-Archive) to the **Acquisition** section (alphabetically between Waybackpy and Web2Warc).
- Wayback-Archive is a Python tool that downloads complete websites from the Wayback Machine with full asset preservation (CSS, JS, images, fonts), Google Fonts support, and automatic Wayback Machine artifact cleanup, producing clean static sites ready for offline viewing.
- It fits the Acquisition category as it enables retrieval and local preservation of web content from the Internet Archive's Wayback Machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)