### PR TITLE
Add Wayback-Archive to Acquisition section

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ This list of tools and software is intended to briefly describe some of the most
 * [WARCreate](http://matkelly.com/warcreate/) - A [Google Chrome](https://www.google.com/intl/en/chrome/browser/) extension for archiving an individual webpage or website to a WARC file. *(Stable)*
 * [Warcworker](https://github.com/peterk/warcworker) - An open source, dockerized, queued, high fidelity web archiver based on Squidwarc with a simple web GUI. *(Stable)*
 * [Wayback](https://github.com/wabarc/wayback) - A toolkit for snapshot webpage to Internet Archive, archive.today, IPFS and beyond. *(Stable)*
+* [Wayback-Archive](https://github.com/GeiserX/Wayback-Archive) - Download complete websites from the Wayback Machine with full asset preservation for offline viewing. *(Stable)*
 * [Waybackpy](https://github.com/akamhy/waybackpy) -  Wayback Machine Save, CDX and availability API interface in Python and a command-line tool  *(Stable)*
 * [Web2Warc](https://github.com/helgeho/Web2Warc) - An easy-to-use and highly customizable crawler that enables anyone to create their own little Web archives (WARC/CDX). *(Stable)*
 * [Web Curator Tool](https://webcuratortool.org) - Open-source workflow management for selective web archiving. *(Stable)*


### PR DESCRIPTION
## Summary
- Adds [Wayback-Archive](https://github.com/GeiserX/Wayback-Archive) to the Acquisition section
- Wayback-Archive downloads complete websites from the Wayback Machine with full asset preservation for offline viewing
- Entry placed in alphabetical order