### PR TITLE
Add Web Resource Ledger (capture) and @w-r-l/verify (verification)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ This list of tools and software is intended to briefly describe some of the most
 * [Waybackpy](https://github.com/akamhy/waybackpy) -  Wayback Machine Save, CDX and availability API interface in Python and a command-line tool  *(Stable)*
 * [Web2Warc](https://github.com/helgeho/Web2Warc) - An easy-to-use and highly customizable crawler that enables anyone to create their own little Web archives (WARC/CDX). *(Stable)*
 * [Web Curator Tool](https://webcuratortool.org) - Open-source workflow management for selective web archiving. *(Stable)*
+* [Web Resource Ledger](https://github.com/benpeter/web-resource-ledger) - Captures web pages as verifiable evidence with Ed25519 signatures, RFC 3161 timestamps, and WACZ archives. Includes an MCP server for AI agent integration. *(Stable)*
 * [WebMemex](https://github.com/WebMemex) - Browser extension for Firefox and Chrome which lets you archive web pages you visit. *(In Development)*
 * [Wget](http://www.gnu.org/software/wget/) - An open source file retrieval utility that of [version 1.14 supports writing warcs](http://www.archiveteam.org/index.php?title=Wget_with_WARC_output). *(Stable)*
 * [Wget-lua](https://github.com/alard/wget-lua) - Wget with Lua extension. *(Stable)*
@@ -137,6 +138,7 @@ This list of tools and software is intended to briefly describe some of the most
 
 ### Utilities
 
+* [@w-r-l/verify](https://www.npmjs.com/package/@w-r-l/verify) - CLI and library to verify cryptographic integrity of WRL WACZ web capture bundles. Checks Ed25519 signatures and RFC 3161 timestamps (Node.js). *(Stable)*
 * [ArchiveTools](https://github.com/recrm/ArchiveTools) - Collection of tools to extract and interact with WARC files (Python).
 * [bagnabit2warc](https://github.com/internetarchive/bagnabit2warc) - Convert a [bag-nabit](https://github.com/harvard-lil/bag-nabit) dataset stored in a ZIP into a full-content WARC.
 * [cdx-toolkit](https://pypi.org/project/cdx-toolkit/) - Library and CLI to consult cdx indexes and create WARC extractions of subsets. Abstracts away Common Crawl's unusual crawl structure. *(Stable)*

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ This list of tools and software is intended to briefly describe some of the most
 * [Waybackpy](https://github.com/akamhy/waybackpy) -  Wayback Machine Save, CDX and availability API interface in Python and a command-line tool  *(Stable)*
 * [Web2Warc](https://github.com/helgeho/Web2Warc) - An easy-to-use and highly customizable crawler that enables anyone to create their own little Web archives (WARC/CDX). *(Stable)*
 * [Web Curator Tool](https://webcuratortool.org) - Open-source workflow management for selective web archiving. *(Stable)*
+* [Web Resource Ledger](https://github.com/benpeter/web-resource-ledger) - Captures web pages as verifiable evidence with Ed25519 signatures, RFC 3161 timestamps, and WACZ archives. Includes an MCP server for AI agent integration. *(Stable)*
 * [WebMemex](https://github.com/WebMemex) - Browser extension for Firefox and Chrome which lets you archive web pages you visit. *(In Development)*
 * [Wget](http://www.gnu.org/software/wget/) - An open source file retrieval utility that of [version 1.14 supports writing warcs](http://www.archiveteam.org/index.php?title=Wget_with_WARC_output). *(Stable)*
 * [Wget-lua](https://github.com/alard/wget-lua) - Wget with Lua extension. *(Stable)*
@@ -153,6 +154,7 @@ This list of tools and software is intended to briefly describe some of the most
 
 ### Utilities
 
+* [@w-r-l/verify](https://www.npmjs.com/package/@w-r-l/verify) - CLI and library to verify cryptographic integrity of WRL WACZ web capture bundles. Checks Ed25519 signatures and RFC 3161 timestamps (Node.js). *(Stable)*
 * [ArchiveTools](https://github.com/recrm/ArchiveTools) - Collection of tools to extract and interact with WARC files (Python).
 * [bagnabit2warc](https://github.com/internetarchive/bagnabit2warc) - Convert a [bag-nabit](https://github.com/harvard-lil/bag-nabit) dataset stored in a ZIP into a full-content WARC.
 * [cdx-toolkit](https://pypi.org/project/cdx-toolkit/) - Library and CLI to consult cdx indexes and create WARC extractions of subsets. Abstracts away Common Crawl's unusual crawl structure. *(Stable)*


### PR DESCRIPTION
Adds two tools to the list:

**Web Resource Ledger** (Acquisition section)
- Captures web pages as verifiable evidence bundles
- Ed25519 signatures + RFC 3161 timestamps + WACZ archives
- Includes MCP server for AI agent integration
- GitHub: https://github.com/benpeter/web-resource-ledger
- Docs: https://docs.webresourceledger.com

**@w-r-l/verify** (Utilities section)
- CLI and Node.js library for verifying WRL capture integrity
- Checks artifact hashes, Ed25519 signatures, and RFC 3161 timestamps
- npm: https://www.npmjs.com/package/@w-r-l/verify

Both tools work with the WACZ standard used by Webrecorder and other web archiving tools.