### PR TITLE
Add Archivarix Tube Search to Search & Discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ This list of tools and software is intended to briefly describe some of the most
 
 ### Search & Discovery
 
+* [Archivarix Tube Search](https://tube.archivarix.net) - Search engine over ~1.5 billion archived YouTube videos using CDX and Memento queries against the Wayback Machine, combined with proprietary captures of YouTube watch and channel pages. Provides full-text search across titles, descriptions, and auto-generated transcripts, plus channel-level browsing of terminated channels. *(Stable)*
 * [hyphe](https://github.com/medialab/hyphe) - A webcrawler built for research uses with a graphical user interface in order to build web corpuses made of lists of web actors and maps of links between them. *(Stable)*
 * [Mink](https://github.com/machawk1/Mink) - A [Google Chrome](https://www.google.com/intl/en/chrome/) extension for querying Memento aggregators while browsing and integrating live-archived web navigation. *(Stable)*
 * [PANDORÆ](https://github.com/Guillaume-Levrier/PANDORAE) - A desktop research software to be plugged on a Solr endpoint to query, retrieve, normalize and visually explore web archives. *(Stable)*


### PR DESCRIPTION
Adds Archivarix Tube Search to the Search & Discovery section.

**Disclosure:** I help maintain this project.

Briefly against the CONTRIBUTING.md criteria:
- Archives content that does not belong to us (YouTube videos at scale)
- Uses widely-accepted web archiving standards: queries are issued against the Wayback Machine via the CDX API and Memento timegate, plus proprietary captures of YouTube watch and channel pages
- Focused on a broad, public, interlinked web platform (YouTube)
- Production-stable, free anonymous tier covers full search and metadata

Inserted alphabetically at the top of Search & Discovery.