### PR TITLE
Add Dead-Web Index to Public Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ This is a list of publicly available WARCs, Wayback Machines, CDX API endpoints,
 
 * [Common Crawl files](https://data.commoncrawl.org/) - WARCs, CDX files, parquet url index, parquet host index, etc.
 * [Common Crawl CDX API](https://index.commoncrawl.org/)
+* [Dead-Web Index](https://github.com/Crawlora-org/dead-web-index-data) - Reachability labels (alive / blocked / dead) for the top 10 million domains, two probe arms (polite HTTP and a browser TLS fingerprint), 2026. CC BY 4.0, JSONL.
 * [End of Term Archive](https://eotarchive.org/) - WARCs, CDX files, parquet url index
 * [Internet Archive Wayback](https://web.archive.org/)
 * [Webrecorder US GovArchive](https://govarchive.us/) - high-fidelity replay


### PR DESCRIPTION
Adds the Dead-Web Index to the Public Data section.

An open dataset (CC BY 4.0, JSONL) labelling the reachability of the DomCop top-10-million domains as alive / blocked / dead, from two probe arms — a polite HTTP client and a browser TLS fingerprint (2026). A public, domain-level snapshot of link rot (what is genuinely gone vs. still reachable), useful for capture prioritisation and link-rot research.

Inserted alphabetically in Public Data, following the entry format. Repo: https://github.com/Crawlora-org/dead-web-index-data